### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/convert-subtitles.py
+++ b/convert-subtitles.py
@@ -61,14 +61,14 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.output_format not in SUPPORTED_WRITERS:
-        parser.error('Output format must be one of %s' % ' '.join(SUPPORTED_WRITERS.keys()))
+        parser.error('Output format must be one of {0!s}'.format(' '.join(SUPPORTED_WRITERS.keys())))
     else:
         output_writer_class = SUPPORTED_WRITERS[args.output_format]
 
     logging.basicConfig()
 
     for f in args.caption_file:
-        output_file = '%s.%s' % (os.path.splitext(f.name)[0],
+        output_file = '{0!s}.{1!s}'.format(os.path.splitext(f.name)[0],
                                  FILE_EXTENSIONS[args.output_format])
 
         print(output_file)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:cdiazbas:pyUtilities?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:cdiazbas:pyUtilities?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
